### PR TITLE
Added global-use script for 'Main' room.

### DIFF
--- a/addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres
+++ b/addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres
@@ -29,4 +29,4 @@ nodes/OpenHand/node = SubResource( 4 )
 nodes/OpenHand/position = Vector2( -600, 100 )
 nodes/Trigger/node = SubResource( 5 )
 nodes/Trigger/position = Vector2( -360, 20 )
-node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "output", 0, "Grip" ]
+node_connections = [ "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "output", 0, "Grip" ]

--- a/addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres
+++ b/addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres
@@ -29,4 +29,4 @@ nodes/OpenHand/node = SubResource( 3 )
 nodes/OpenHand/position = Vector2( -600, 100 )
 nodes/Trigger/node = SubResource( 5 )
 nodes/Trigger/position = Vector2( -360, 40 )
-node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "output", 0, "Grip" ]
+node_connections = [ "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "output", 0, "Grip" ]

--- a/scenes/main/Main_Room.tscn
+++ b/scenes/main/Main_Room.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=2]
+[gd_scene load_steps=35 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/player/player_body.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scenes/objects/pc_tower/case.tscn" type="PackedScene" id=2]
@@ -19,6 +19,7 @@
 [ext_resource path="res://scenes/objects/pc_tower/pickable_motherboard.tscn" type="PackedScene" id=17]
 [ext_resource path="res://addons/godot-xr-tools/misc/vr_common_shader_cache.tscn" type="PackedScene" id=18]
 [ext_resource path="res://addons/godot-openxr/scenes/first_person_controller_vr.tscn" type="PackedScene" id=19]
+[ext_resource path="res://scripts/main_room.gd" type="Script" id=20]
 
 [sub_resource type="BoxShape" id=10]
 extents = Vector3( 50, 1, 50 )
@@ -71,6 +72,7 @@ extents = Vector3( 0.497, 0.124, 0.127 )
 albedo_color = Color( 0.223529, 0.545098, 0.698039, 1 )
 
 [node name="MainRoom" type="Spatial"]
+script = ExtResource( 20 )
 
 [node name="FPController" parent="." instance=ExtResource( 19 )]
 transform = Transform( -1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, 0 )

--- a/scenes/objects/pc_tower/pickable_fans.tscn
+++ b/scenes/objects/pc_tower/pickable_fans.tscn
@@ -48,7 +48,7 @@ closed_pose = ExtResource( 8 )
 [node name="PickableFans" instance=ExtResource( 2 )]
 
 [node name="CollisionShape" parent="." index="0"]
-transform = Transform( 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0.546414, -0.107584, -0.205 )
+transform = Transform( 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, -0.0242255, -0.107584, -0.205 )
 shape = SubResource( 1 )
 
 [node name="Fans" parent="." index="1" instance=ExtResource( 1 )]

--- a/scripts/main_room.gd
+++ b/scripts/main_room.gd
@@ -1,0 +1,11 @@
+extends Spatial
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#	pass


### PR DESCRIPTION
This is to preparing for the actual snapping system (low-effort implementing for sure) when player hold the components on hands and connect it with the snap area inside the PC case.

Correctly transform the hitbox for one of the PC parts - Fan, which somehow was not properly moved by accidentally.